### PR TITLE
Use CubeCore instead of PlugCubeBuildersIn to create a player head

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,5 @@
 A Bukkit plugin linking to BungeeCord to send players to a server
 
 ## Dependencies    
-- [PlugCubeBuildersIn](https://github.com/CubeBuilders/PlugCubeBuildersIn)    
+- [CubeCore](https://github.com/CubeBuilders/CubeCore)    
 - [SmartInvs](https://github.com/MinusKube/SmartInvs)

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>io.siggi</groupId>
-            <artifactId>PlugCubeBuildersIn</artifactId>
+            <artifactId>CubeCore</artifactId>
             <version>1.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>

--- a/src/main/java/uk/asheiou/bungeecompass/menu/MainMenu.java
+++ b/src/main/java/uk/asheiou/bungeecompass/menu/MainMenu.java
@@ -4,7 +4,7 @@ import fr.minuskube.inv.ClickableItem;
 import fr.minuskube.inv.content.InventoryContents;
 import fr.minuskube.inv.content.InventoryProvider;
 import fr.minuskube.inv.SmartInventory;
-import hk.siggi.bukkit.plugcubebuildersin.PlugCubeBuildersIn;
+import io.siggi.cubecore.bukkit.CubeCoreBukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -48,7 +48,7 @@ public class MainMenu implements InventoryProvider {
             Material material = Material.getMaterial(servers.getString(s+".item.material")); assert material != null;
             ItemStack itemStack = null;
             if (material == Material.PLAYER_HEAD) {
-                itemStack = PlugCubeBuildersIn.getInstance().createSkull(UUID.fromString(servers.getString(s + ".item.uuid")));
+                itemStack = CubeCoreBukkit.createPlayerHead(UUID.fromString(servers.getString(s + ".item.uuid")));
             } else {
                 itemStack = new ItemStack(material);
             }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ author: Asheiou
 api-version: 1.17
 depend:
   - SmartInvs
-  - PlugCubeBuildersIn
+  - CubeCore
 commands:
   beta:
     description: Open the beta features menu


### PR DESCRIPTION
Use of PlugCubeBuildersIn as a library plugin is being deprecated.